### PR TITLE
fix: Add permissions section for workflow to enable content write access

### DIFF
--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write    
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/deploy-oci.yml` file, updating the workflow permissions to allow write access to repository contents.