### PR TITLE
🚨 Hotfix: Fix critical Terraform source_details syntax error

### DIFF
--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -157,7 +157,7 @@ resource "oci_core_instance" "stt_api_instance" {
   
   source_details {
     source_type = "image"
-    image_id = var.image_id != "" ? var.image_id : data.oci_core_images.oracle_linux.images[0].id
+    source_id = var.image_id != "" ? var.image_id : data.oci_core_images.oracle_linux.images[0].id
   }
   
   metadata = {


### PR DESCRIPTION
## 🚨 Critical Fix Required

### 🐛 Problem
- **Deployment blocking error**:  
- **Location**:  line 160 in  resource
- **Impact**: OCI Resource Manager deployment completely fails

### ✅ Solution  
- **Fixed**: Change  to  in  block
- **Reason**: OCI Terraform provider expects , not 
- **Validation**: Follows official OCI provider documentation

### 📝 Changes
```diff
  source_details {
    source_type = "image"
-   image_id = var.image_id != "" ? var.image_id : data.oci_core_images.oracle_linux.images[0].id
+   source_id = var.image_id != "" ? var.image_id : data.oci_core_images.oracle_linux.images[0].id
  }
```

### 🧪 Testing
- [x] Terraform syntax validation resolved
- [x] OCI provider specification compliance
- [ ] OCI Resource Manager deployment test pending

### ⚡ Priority
- **High Priority**: Blocks all OCI deployments
- **Type**: Hotfix (critical syntax error)
- **Target**: main branch (immediate merge recommended)

### 📚 References
- OCI Terraform Provider: [oci_core_instance resource](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/core_instance)
- Related issue: Terraform validation error during OCI RM deployment

## ✅ Ready for Review & Merge
This is a critical syntax fix that should be merged immediately to unblock deployments.